### PR TITLE
Fix link to Pyenv installer

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,7 +37,7 @@ __Install brew dependencies:__
 
 __Install Pyenv:__
 
-- install Pyenv using ![Pyenv Installer](https://github.com/pyenv/pyenv-installer) instead of brew (will allow a working 3.9.1 install)
+- install Pyenv using [Pyenv Installer](https://github.com/pyenv/pyenv-installer) instead of brew (will allow a working 3.9.1 install)
 
 `curl -L https://github.com/pyenv/pyenv-installer/raw/master/bin/pyenv-installer | bash`
 


### PR DESCRIPTION
**Before** 
<img width="859" alt="Screenshot 2021-04-29 at 11 00 18" src="https://user-images.githubusercontent.com/1256298/116519453-2ca0ba80-a8da-11eb-9888-c1e92ed282db.png">

---

**After**
<img width="772" alt="Screenshot 2021-04-29 at 11 00 10" src="https://user-images.githubusercontent.com/1256298/116519518-3aeed680-a8da-11eb-80e4-6903e8ff5d01.png">
